### PR TITLE
Fixed broken lithuanian translation.

### DIFF
--- a/src/js/select2/i18n/lt.js
+++ b/src/js/select2/i18n/lt.js
@@ -1,14 +1,12 @@
 define(function () {
-  // Italian
-  function ending (count, first, second, third) {
-    if ((count % 100 > 9 && count % 100 < 21) || count % 10 === 0) {
-      if (count % 10 > 1) {
-        return second;
-      } else {
-        return third;
-      }
+  // rules from http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#lt
+  function ending(count, one, few, other) {
+    if (count % 10 === 1 && (count % 100 < 11 || count % 100 > 19)) {
+      return one;
+    } else if ((count % 10 >= 2 && count % 10 <= 9) && (count % 100 < 11 || count % 100 > 19)) {
+      return few;
     } else {
-      return first;
+      return other;
     }
   }
 
@@ -18,7 +16,7 @@ define(function () {
 
       var message = 'Pašalinkite ' + overChars + ' simbol';
 
-      message += ending(overChars, 'ių', 'ius', 'į');
+      message += ending(overChars, 'į', 'ius', 'ių');
 
       return message;
     },
@@ -27,7 +25,7 @@ define(function () {
 
       var message = 'Įrašykite dar ' + remainingChars + ' simbol';
 
-      message += ending(remainingChars, 'ių', 'ius', 'į');
+      message += ending(remainingChars, 'į', 'ius', 'ių');
 
       return message;
     },
@@ -37,7 +35,7 @@ define(function () {
     maximumSelected: function (args) {
       var message = 'Jūs galite pasirinkti tik ' + args.maximum + ' element';
 
-      message += ending(args.maximum, 'ų', 'us', 'ą');
+      message += ending(args.maximum, 'ą', 'us', 'ų');
 
       return message;
     },


### PR DESCRIPTION
This pull request includes a
- [x] Bug fix
- [ ] New feature
- [x] Translation

The following changes were made
Changed the way Lithuanian endings of the word are generated.

Ticket: https://github.com/select2/select2/issues/4301

Before (incorrect):
Įrašykite dar/Pašalinkite 1simbolių
Įrašykite dar/Pašalinkite 2simbolių
Įrašykite dar/Pašalinkite 3simbolių
Įrašykite dar/Pašalinkite 4simbolių
Įrašykite dar/Pašalinkite 5simbolių
Įrašykite dar/Pašalinkite 6simbolių
Įrašykite dar/Pašalinkite 7simbolių
Įrašykite dar/Pašalinkite 8simbolių
Įrašykite dar/Pašalinkite 9simbolių
Įrašykite dar/Pašalinkite 10simbolį
Įrašykite dar/Pašalinkite 11simbolį
Įrašykite dar/Pašalinkite 12simbolius
Įrašykite dar/Pašalinkite 19simbolius
Įrašykite dar/Pašalinkite 20simbolį
Įrašykite dar/Pašalinkite 21simbolių
Įrašykite dar/Pašalinkite 71simbolių
Įrašykite dar/Pašalinkite 99simbolių
Įrašykite dar/Pašalinkite 100simbolį

After (correct):
Įrašykite dar/Pašalinkite 1 simbolį
Įrašykite dar/Pašalinkite 2 simbolius
Įrašykite dar/Pašalinkite 3 simbolius
Įrašykite dar/Pašalinkite 4 simbolius
Įrašykite dar/Pašalinkite 5 simbolius
Įrašykite dar/Pašalinkite 6 simbolius
Įrašykite dar/Pašalinkite 7 simbolius
Įrašykite dar/Pašalinkite 8 simbolius
Įrašykite dar/Pašalinkite 9 simbolius
Įrašykite dar/Pašalinkite 10 simbolių
Įrašykite dar/Pašalinkite 11 simbolių
Įrašykite dar/Pašalinkite 12 simbolių
Įrašykite dar/Pašalinkite 19 simbolių
Įrašykite dar/Pašalinkite 20 simbolių
Įrašykite dar/Pašalinkite 21 simbolį
Įrašykite dar/Pašalinkite 71 simbolį
Įrašykite dar/Pašalinkite 99 simbolius
Įrašykite dar/Pašalinkite 100 simbolių
